### PR TITLE
Bug #3, Tweaks to where and how configuration options are set and used

### DIFF
--- a/engine/settings.CLIPIT-example.php
+++ b/engine/settings.CLIPIT-example.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Defines database credentials.
+ *
+ * Most of Elgg's configuration is stored in the database.  This file contains the
+ * credentials to connect to the database, as well as a few optional configuration
+ * values.
+ *
+ * The Elgg installation attempts to populate this file with the correct settings
+ * and then rename it to settings.php.
+ *
+ * @todo Turn this into something we handle more automatically.
+ * @package Elgg.Core
+ * @subpackage Configuration
+ */
+
+global $CONFIG;
+if (!isset($CONFIG)) {
+	$CONFIG = new stdClass;
+}
+
+/*
+ * Standard configuration
+ *
+ * You will use the same database connection for reads and writes.
+ * This is the easiest configuration, and will suit 99.99% of setups. However, if you're
+ * running a really popular site, you'll probably want to spread out your database connections
+ * and implement database replication.  That's beyond the scope of this configuration file
+ * to explain, but if you know you need it, skip past this section.
+ */
+
+/**
+ * The database username
+ *
+ * @global string $CONFIG->dbuser
+ * @name $CONFIG->dbuser
+ */
+$CONFIG->dbuser = '{{dbuser}}';
+
+/**
+ * The database password
+ *
+ * @global string $CONFIG->dbpass
+ */
+$CONFIG->dbpass = '{{dbpassword}}';
+
+/**
+ * The database name
+ *
+ * @global string $CONFIG->dbname
+ */
+$CONFIG->dbname = '{{dbname}}';
+
+/**
+ * The database host.
+ *
+ * For most installations, this is 'localhost'
+ *
+ * @global string $CONFIG->dbhost
+ */
+$CONFIG->dbhost = '{{dbhost}}';
+
+/**
+ * The database prefix
+ *
+ * This prefix will be appended to all Elgg tables.  If you're sharing
+ * a database with other applications, use a database prefix to namespace tables
+ * in order to avoid table name collisions.
+ *
+ * @global string $CONFIG->dbprefix
+ */
+$CONFIG->dbprefix = '{{dbprefix}}';
+
+
+/**
+ * Memcache setup (optional)
+ * This is where you may optionally set up memcache.
+ *
+ * Requirements:
+ * 	1) One or more memcache servers (http://www.danga.com/memcached/)
+ *  2) PHP memcache wrapper (http://uk.php.net/manual/en/memcache.setup.php)
+ *
+ * Note: Multiple server support is only available on server 1.2.1
+ * or higher with PECL library > 2.0.0
+ */
+//$CONFIG->memcache = true;
+//
+//$CONFIG->memcache_servers = array (
+//	array('server1', 11211),
+//	array('server2', 11211)
+//);
+
+
+/**
+ * Use non-standard headers for broken MTAs.
+ *
+ * The default header EOL for headers is \r\n.  This causes problems
+ * on some broken MTAs.  Setting this to TRUE will cause Elgg to use
+ * \n, which will fix some problems sending email on broken MTAs.
+ *
+ * @global bool $CONFIG->broken_mta
+ */
+$CONFIG->broken_mta = FALSE;
+
+/**
+ * Disable the database query cache
+ *
+ * Elgg stores each query and its results in a query cache.
+ * On large sites or long-running scripts, this cache can grow to be
+ * large.  To disable query caching, set this to TRUE.
+ *
+ * @global bool $CONFIG->db_disable_query_cache
+ */
+$CONFIG->db_disable_query_cache = FALSE;
+
+/**
+ * Minimum password length
+ *
+ * This value is used when validating a user's password during registration.
+ *
+ * @global int $CONFIG->min_password_length
+ */
+$CONFIG->min_password_length = 6;
+
+
+/**
+ * JuxtaLearn Cookie Authentication
+ */
+$CONFIG->JXL_COOKIE_SECRET = NULL;
+//$CONFIG->JXL_COOKIE_DOMAIN = '.escet.urjc.es';  // Un-comment whichever is appropriate.
+//$CONFIG->JXL_COOKIE_DOMAIN = '.juxtalearn.net';
+
+
+#End.

--- a/mod/clipit_api/classes/ClipitUser.php
+++ b/mod/clipit_api/classes/ClipitUser.php
@@ -53,7 +53,13 @@ class ClipitUser extends UBUser{
         $user = static::get_by_login(array($login));
         $user = $user[$login];
         $token = UBSite::get_token($login, $password, static::COOKIE_TOKEN_DURATION);
-        $jxl_cookie_auth = new JuxtaLearn_Cookie_Authentication($CONFIG->JXL_SECRET, get_site_domain($site->guid));
+        try {
+            $jxl_cookie_auth = new JuxtaLearn_Cookie_Authentication(
+                    $CONFIG->JXL_COOKIE_SECRET, $CONFIG->JXL_COOKIE_DOMAIN);
+        } catch (Exception $ex) {
+            // Error - I don't know how to hook into Elgg error handling/reporting.
+            die(get_class($jxl_cookie_auth) .': '. $ex->getMessage());
+        }
         $jxl_cookie_auth->set_required_cookie($user->login, $user->role, $user->id);
         $jxl_cookie_auth->set_name_cookie($user->name);
         $jxl_cookie_auth->set_token_cookie($token);
@@ -62,8 +68,12 @@ class ClipitUser extends UBUser{
     static function delete_cookies(){
         global $CONFIG;
         UBSite::remove_token($_COOKIE["clipit_token"]);
-        $site = elgg_get_site_entity();
-        $jxl_cookie_auth = new JuxtaLearn_Cookie_Authentication($CONFIG->JXL_SECRET, get_site_domain($site->guid));
+        try {
+            $jxl_cookie_auth = new JuxtaLearn_Cookie_Authentication(
+                    $CONFIG->JXL_COOKIE_SECRET, $CONFIG->JXL_COOKIE_DOMAIN);
+        } catch (Exception $ex) {
+            die(get_class($jxl_cookie_auth) .': '. $ex->getMessage());
+        }
         $jxl_cookie_auth->delete_cookies();
     }
 

--- a/mod/clipit_api/start.php
+++ b/mod/clipit_api/start.php
@@ -23,7 +23,7 @@ function clipit_api_init(){
     global $CONFIG;
     loadFiles(elgg_get_plugins_path() . "clipit_api/libraries/");
     clipit_expose_api();
-    $CONFIG->JXL_SECRET = "697fe3f81946fb59a714471cd688360b";
+    //$CONFIG->JXL_SECRET; -- See '/engine/settings.CLIPIT-example.php'
 }
 
 function clipit_register_subtypes(){


### PR DESCRIPTION
Hi Pablo,

As promised, here is a patch - do you want to add Elgg error handling in the try-catches?
- Includes an example `settings.php`
- Uses a try-catch - for exceptions raised for a missing/bad secret key
- TODO: as I don't know about Elgg error handling it uses a PHP "die()"

Relates to: [JuxtaLearn Cookie Authentication library](https://github.com/juxtalearn/juxtalearn-cookie-authentication).
- And, bug #3.

Thanks,

Nick
